### PR TITLE
[Feat] NetworkManager 구현

### DIFF
--- a/Honzapda/Network/NetworkManager.swift
+++ b/Honzapda/Network/NetworkManager.swift
@@ -6,3 +6,86 @@
 //
 
 import Foundation
+
+import Alamofire
+
+
+class APIManager: ObservableObject  {
+    static let shared = APIManager()
+    private var headers: HTTPHeaders = []
+}
+
+
+// MARK: T에는 요청값 데이터의 모델, U에는 응닶값 데이터의 모델 적기
+
+extension APIManager {
+    func getData<T: Codable, U: Decodable>(urlEndpointString: String,
+                                           responseDataType: U.Type,
+                                           requestDataType: T.Type,
+                                           parameter: T?,
+                                           completionHandler: @escaping (U)->Void
+    ){
+        
+        guard let url = URL(string: BaseURL.baseURL + urlEndpointString) else { return }
+        print("get 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(String(describing: parameter))")
+        
+        AF
+            .request(url, method: .get, parameters: parameter, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    func postData<T: Codable, U: Decodable>(urlEndpointString: String,
+                                            responseDataType: U.Type,
+                                            requestDataType: T.Type,
+                                            parameter: T?,
+                                            completionHandler: @escaping (U)->Void) {
+        guard let url = URL(string: BaseURL.baseURL + urlEndpointString) else { return }
+        print("post 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(String(describing: parameter))")
+
+        AF
+            .request(url, method: .post, parameters: parameter, encoder: .json, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+    
+    func deleteData<T: Codable, U: Decodable>(urlEndpointString: String,
+                                            responseDataType: U.Type,
+                                            requestDataType: T.Type,
+                                            parameter: T?,
+                                            completionHandler: @escaping (U)->Void) {
+        
+        guard let url = URL(string: BaseURL.baseURL + urlEndpointString) else { return }
+        print("patch 요청 URL --> \(url)")
+        print("Request 쿼리 --> \(parameter)")
+        
+        AF
+            .request(url, method: .delete, parameters: parameter, encoder: .json, headers: self.headers)
+            .responseDecodable(of: U.self) { response in
+                switch response.result {
+                case .success(let success):
+                    completionHandler(success)
+                case .failure(let error):
+                    print(error.localizedDescription)
+                }
+            }
+            .resume()
+    }
+}
+

--- a/Honzapda/Network/NetworkManager.swift
+++ b/Honzapda/Network/NetworkManager.swift
@@ -72,7 +72,7 @@ extension APIManager {
                                             completionHandler: @escaping (U)->Void) {
         
         guard let url = URL(string: BaseURL.baseURL + urlEndpointString) else { return }
-        print("patch 요청 URL --> \(url)")
+        print("delete 요청 URL --> \(url)")
         print("Request 쿼리 --> \(parameter)")
         
         AF


### PR DESCRIPTION
## 🔥 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #17 
- [x] 이슈 해결 여부

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- API 연결을 위한 NetworkManager를 구현했습니다.

## 💻 주요 코드 설명
<!-- 코드 설명 작성해주세요 -->
`BaseURL`
```swift
//
//  BaseURL.swift
//  Honzapda
//
//  Created by YOUJIM on 2/28/24.
//

import Foundation


class BaseURL {
    static let baseURL = "혼잡다 BaseURL"
}
```
- 기본 BaseURL Secret 처리를 위해 따로 클래스 빼서 처리했고, static 상수로 처리해서 API 연결 작업 시 가져와서 사용할 수 있도록 했습니다.
- 파일은 따로 전달드리겠습니다! `Global` > `Privates` 폴더 안에 넣어주세요.

`NetworkManager`
- Alamofire 라이브러리 이용해서 NetworkManager 작업했습니다.
```swift
//
//  NetworkManager.swift
//  Honzapda
//
//  Created by YOUJIM on 2/28/24.
//

import Foundation

import Alamofire


class APIManager: ObservableObject  {
    static let shared = APIManager()
    private var headers: HTTPHeaders = []
}
```
- ObservableObject로 선언한 APIManager 클래스에서 싱글톤으로 사용하기 위한 APIManager 객체를 선언합니다.
- 추후 헤더 처리를 위한 header 객체를 선언합니다.

```swift
extension APIManager {
    func getData<T: Codable, U: Decodable>(urlEndpointString: String,
                                           responseDataType: U.Type,
                                           requestDataType: T.Type,
                                           parameter: T?,
                                           completionHandler: @escaping (U)->Void
    ){
        
        guard let url = URL(string: BaseURL.baseURL + urlEndpointString) else { return }
        print("get 요청 URL --> \(url)")
        print("Request 쿼리 --> \(String(describing: parameter))")
        
        AF
            .request(url, method: .get, parameters: parameter, headers: self.headers)
            .responseDecodable(of: U.self) { response in
                switch response.result {
                case .success(let success):
                    completionHandler(success)
                case .failure(let error):
                    print(error.localizedDescription)
                }
            }
            .resume()
    }
```
- APIManager Extension에서 `get`, `post`, `delete` 방식으로 데이터를 통신하기 위한 함수를 각각 `getData`, `postData`, `deleteData` 방식으로 선언합니다.
`.request` 부분에서 method만 다르고 다른 부분은 전부 똑같아서 getData만 설명하겠습니다!
- T는 요청값 데이터의 모델, U는 응답값 데이터의 모델을 작성하게 됩니다.
이 때 모델은 모두 각 페이지 모델 폴더에서 작업하게 되며, 서버 스웨거를 참고해 타입에 맞게 생성해야 합니다.
모델 예시:
```swift
struct UserInfoRequestModel: Codable {
    
}

struct UserInfoResponseModel: Codable {
    let id: Int?
    let token: String?
    let name: String?
}
```
- 파라미터의 경우 `urlEndpointString`, `responseDataType`, `requestDataType`, `parameter`, `completionHandler`를 받게 됩니다.
`urlEndpointString`은 API 연결 시 BaseURL 뒤에 붙는 엔드포인트를 의미합니다. `NetworkConstant` 클래스에 `static`으로 선언하고 사용합니다. 
사용 예시:
```swift
//
//  NetworkConstant.swift
//  Honzapda
//
//  Created by YOUJIM on 2/28/24.
//

import Foundation


struct Constant {
    static let createUser = "/user"
}
```
- `responseDataType`은 응답값 데이터의 모델(T), `requestDataType`은 요청값 데이터의 모델(U)을 작성하시면 됩니다.
- 만약 API에서 요청값 데이터를 요구하지 않는다고 해도 모델을 파라미터로 작성하셔야 하기 때문에 모델 선언 후 안을 비워두시고 사용하시면 됩니다.
- `parameter`에는 요청값 데이터를 넣게 됩니다. 이 때 타입은 U로 작성합니다.
- `completionHandler`에는 성공적으로 API 응답을 받았을 때 실행될 구문을 작성합니다. (보통 클로저로 열어서 합니다!)

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

## 👀 기타 더 이야기해볼 점
- 보시고 이해 안가시는 부분 있으시면 불러주십쇼!

